### PR TITLE
Add ternary for checking node environment in login

### DIFF
--- a/src/Helpers/utils/AuthService.js
+++ b/src/Helpers/utils/AuthService.js
@@ -9,7 +9,11 @@ export default class AuthService extends EventEmitter {
     super()
     this.lock = new Auth0Lock(clientId, domain, {
       auth: {
-        redirectUrl: 'http://localhost:3000/login',
+        redirectUrl: !process.env.NODE_ENV || process.env.NODE_ENV === "development" ? (
+          'http://localhost:3000/login'
+        ) : (
+          'https://johariwindow.herokuapp.com/login'
+        ),
         responseType: 'token'
       }
     })


### PR DESCRIPTION
@Tman22 @mlimberg this should fix our redirect problem! I `console.log`ed `process.env.NODE_ENV` locally and got `development`, so this should work, but we'll just have to see if it works in production manually.

Ready to merge!