### PR TITLE
Remove undefined env option in ternary

### DIFF
--- a/src/Helpers/utils/AuthService.js
+++ b/src/Helpers/utils/AuthService.js
@@ -7,9 +7,10 @@ import * as actions from '../../Redux/actions'
 export default class AuthService extends EventEmitter {
   constructor(clientId, domain) {
     super()
+    console.log("environment:", process.env.NODE_ENV)
     this.lock = new Auth0Lock(clientId, domain, {
       auth: {
-        redirectUrl: !process.env.NODE_ENV || process.env.NODE_ENV === "development" ? (
+        redirectUrl: process.env.NODE_ENV === "development" ? (
           'http://localhost:3000/login'
         ) : (
           'https://johariwindow.herokuapp.com/login'


### PR DESCRIPTION
@mlimberg the last change didn't do it, in case NODE_ENV is undefined in production, I took out that case to see if it makes a difference.

Thanks!