### PR TITLE
Remove unneccessary div to fix submit hover issue

### DIFF
--- a/src/Components/Johari/JohariSubmit/JohariSubmit.js
+++ b/src/Components/Johari/JohariSubmit/JohariSubmit.js
@@ -28,9 +28,7 @@ class JohariSubmit extends Component {
 
   activeSubmit() {
     return (
-      <div className={'JohariSubmit active-submit'}>
-        <Link onClick={this.submit} to='/'>Submit</Link>
-      </div>
+        <Link onClick={this.submit} to='/' className={'JohariSubmit active-submit'}>Submit</Link>
     )
   }
 


### PR DESCRIPTION
Fixes issue #29 

Button was wrapped in unnecessary `<div>` that held the className instead of the link itself. Removed the div and added class to the Link. 

@tmikeschu 